### PR TITLE
Assign "flags" field when retrieving a pose

### DIFF
--- a/RemoteCaptury.cpp
+++ b/RemoteCaptury.cpp
@@ -2502,6 +2502,7 @@ CapturyPose* RemoteCaptury::getCurrentPoseAndTrackingConsistencyForActor(int act
 	pose->timestamp = it->second.currentPose.timestamp;
 	pose->numTransforms = it->second.currentPose.numTransforms;
 	pose->transforms = (CapturyTransform*)&pose[1];
+	pose->flags = it->second.currentPose.flags;
 	pose->numBlendShapes = it->second.currentPose.numBlendShapes;
 	pose->blendShapeActivations = (float*)(((CapturyTransform*)&pose[1]) + pose->numTransforms);
 


### PR DESCRIPTION
When reading the pose returned by Captury_getCurrentPose, the `flags` field contains rubbish (because it's not assigned). 

I assign the `flags` from the `currentPose` so it has at a value. I haven't managed to get a value in the `flags` field using `CAPTURY_STREAM_FOOT_CONTACT` so I cannot confirm if it works or not, looks better though.